### PR TITLE
Add log import/export UI and handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UWENGINE Logs</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1>UWENGINE Logs</h1>
+        <p>Export and import generated outcome logs.</p>
+      </header>
+      <section class="app__controls">
+        <button id="exportLogsButton" type="button">Export logs</button>
+        <label class="file-input">
+          <span class="file-input__label">Import logs</span>
+          <input id="importLogsInput" type="file" accept="application/json" />
+        </label>
+      </section>
+      <section class="app__status" aria-live="polite">
+        <p id="statusMessage" class="status-message" hidden></p>
+      </section>
+      <section class="app__table">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Timestamp</th>
+              <th scope="col">Summary</th>
+            </tr>
+          </thead>
+          <tbody id="historyTableBody"></tbody>
+        </table>
+      </section>
+    </main>
+    <script src="scripts/app.js" type="module"></script>
+  </body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,314 @@
+const STORAGE_KEY = 'uwengine.outcomeLogs';
+
+/**
+ * @typedef {Object} OutcomeLog
+ * @property {string | number} timestamp - When the log was created.
+ * @property {string} [summary]
+ * @property {string} [result]
+ * @property {string} [outcome]
+ * @property {string} [title]
+ * @property {string} [message]
+ * @property {string} [description]
+ * @property {unknown} [details]
+ */
+
+/**
+ * Global application state. Exposed on window for ease of debugging/tests.
+ * @type {{ logs: OutcomeLog[] }}
+ */
+export const state = {
+  logs: [],
+};
+
+if (typeof window !== 'undefined') {
+  window.state = state;
+}
+
+const tableBody = document.getElementById('historyTableBody');
+const statusMessage = document.getElementById('statusMessage');
+const exportLogsButton = document.getElementById('exportLogsButton');
+const importLogsInput = document.getElementById('importLogsInput');
+
+/**
+ * Loads persisted logs from localStorage.
+ * @returns {OutcomeLog[]}
+ */
+function loadLogsFromStorage() {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    const validated = validateOutcomeLogArray(parsed);
+    return validated ?? [];
+  } catch (error) {
+    console.error('Failed to parse logs from storage', error);
+    return [];
+  }
+}
+
+/**
+ * Persists the current log collection to localStorage.
+ */
+function persistLogs() {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.logs));
+  } catch (error) {
+    console.error('Unable to persist logs', error);
+  }
+}
+
+/**
+ * Updates the status message container.
+ * @param {string} message
+ * @param {'info' | 'error' | 'success'} [variant]
+ */
+function setStatus(message, variant = 'info') {
+  if (!statusMessage) {
+    return;
+  }
+
+  if (!message) {
+    statusMessage.hidden = true;
+    statusMessage.textContent = '';
+    statusMessage.dataset.variant = 'info';
+    return;
+  }
+
+  statusMessage.hidden = false;
+  statusMessage.textContent = message;
+  statusMessage.dataset.variant = variant;
+}
+
+/**
+ * Formats a timestamp into a readable string.
+ * @param {OutcomeLog['timestamp']} timestamp
+ */
+function formatTimestamp(timestamp) {
+  if (timestamp instanceof Date) {
+    return timestamp.toLocaleString();
+  }
+
+  const numeric = Number(timestamp);
+  if (!Number.isNaN(numeric)) {
+    const asDate = new Date(numeric);
+    if (!Number.isNaN(asDate.getTime())) {
+      return asDate.toLocaleString();
+    }
+  }
+
+  const asDate = new Date(String(timestamp));
+  if (!Number.isNaN(asDate.getTime())) {
+    return asDate.toLocaleString();
+  }
+
+  return String(timestamp);
+}
+
+/**
+ * Chooses a human-friendly summary for a log entry.
+ * @param {OutcomeLog} log
+ */
+function summariseLog(log) {
+  const candidates = ['summary', 'result', 'outcome', 'message', 'title', 'description'];
+  for (const key of candidates) {
+    const value = log[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  const clean = { ...log };
+  delete clean.timestamp;
+  return Object.keys(clean).length ? JSON.stringify(clean) : '—';
+}
+
+/**
+ * Re-renders the table that displays log history.
+ */
+export function refreshHistoryTable() {
+  if (!tableBody) {
+    return;
+  }
+
+  tableBody.innerHTML = '';
+
+  if (!Array.isArray(state.logs) || state.logs.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 2;
+    cell.textContent = 'No logs yet.';
+    row.appendChild(cell);
+    tableBody.appendChild(row);
+    return;
+  }
+
+  for (const log of state.logs) {
+    const row = document.createElement('tr');
+
+    const timestampCell = document.createElement('td');
+    timestampCell.textContent = formatTimestamp(log.timestamp);
+    row.appendChild(timestampCell);
+
+    const summaryCell = document.createElement('td');
+    summaryCell.textContent = summariseLog(log);
+    row.appendChild(summaryCell);
+
+    tableBody.appendChild(row);
+  }
+}
+
+/**
+ * Validates a value as an OutcomeLog object.
+ * @param {unknown} value
+ * @returns {value is OutcomeLog}
+ */
+function isOutcomeLog(value) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  if (!('timestamp' in value)) {
+    return false;
+  }
+
+  const { timestamp } = /** @type {{ timestamp: unknown }} */ (value);
+  return (
+    timestamp instanceof Date ||
+    typeof timestamp === 'string' ||
+    typeof timestamp === 'number'
+  );
+}
+
+/**
+ * Ensures an unknown value is an array of OutcomeLogs.
+ * @param {unknown} value
+ * @returns {OutcomeLog[] | null}
+ */
+function validateOutcomeLogArray(value) {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const logs = [];
+  for (const entry of value) {
+    if (!isOutcomeLog(entry)) {
+      return null;
+    }
+    logs.push({ ...entry });
+  }
+
+  return logs;
+}
+
+/**
+ * Triggers an export of the current logs as a JSON file.
+ */
+function handleExportLogs() {
+  try {
+    const payload = JSON.stringify(state.logs, null, 2);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'uw_logs.json';
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+    setStatus('Logs exported successfully.', 'success');
+  } catch (error) {
+    console.error('Failed to export logs', error);
+    setStatus('Unable to export logs. Check console for details.', 'error');
+  }
+}
+
+/**
+ * Reads an uploaded file and merges it into the application state.
+ * @param {Event} event
+ */
+function handleImportLogs(event) {
+  const input = /** @type {HTMLInputElement} */ (event.target);
+  const file = input.files && input.files[0];
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        throw new Error('Unexpected file content.');
+      }
+
+      const parsed = JSON.parse(result);
+      const logs = validateOutcomeLogArray(parsed);
+      if (!logs) {
+        throw new Error('File is not a valid OutcomeLog collection.');
+      }
+
+      state.logs = logs;
+      persistLogs();
+      refreshHistoryTable();
+      setStatus(`Imported ${logs.length} logs successfully.`, 'success');
+    } catch (error) {
+      console.error('Failed to import logs', error);
+      setStatus('Unable to import logs. Ensure the file contains a valid log array.', 'error');
+    } finally {
+      input.value = '';
+    }
+  };
+
+  reader.onerror = () => {
+    console.error('Error reading log file', reader.error);
+    setStatus('Unable to read the selected file.', 'error');
+    input.value = '';
+  };
+
+  reader.readAsText(file);
+}
+
+function attachEventHandlers() {
+  if (exportLogsButton) {
+    exportLogsButton.addEventListener('click', handleExportLogs);
+  }
+
+  if (importLogsInput) {
+    importLogsInput.addEventListener('change', handleImportLogs);
+  }
+}
+
+function initialise() {
+  state.logs = loadLogsFromStorage();
+
+  if (state.logs.length === 0) {
+    // Provide an initial sample log so the interface has content.
+    state.logs = [
+      {
+        timestamp: Date.now(),
+        summary: 'Initial log created. Use the controls above to manage logs.',
+      },
+    ];
+    persistLogs();
+  }
+
+  refreshHistoryTable();
+  attachEventHandlers();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialise, { once: true });
+} else {
+  initialise();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,152 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  background: #f6f8fb;
+  color: #1f2933;
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 5vw, 2.75rem);
+}
+
+.app__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+button,
+.file-input__label {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.65rem 1.25rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+button:hover,
+.file-input__label:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.2);
+}
+
+button:focus-visible,
+.file-input__label:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.5);
+  outline-offset: 3px;
+}
+
+.file-input input[type='file'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.file-input {
+  position: relative;
+  overflow: hidden;
+}
+
+.app__table table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+}
+
+.app__table th,
+.app__table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+}
+
+.app__table thead {
+  background: #1f2937;
+  color: #fff;
+}
+
+.app__table tbody tr:nth-child(every) {
+  background: #f9fafb;
+}
+
+.app__table tbody tr:nth-child(2n) {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.status-message {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.status-message[hidden] {
+  display: none;
+}
+
+.status-message[data-variant='error'] {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.status-message[data-variant='success'] {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: #e2e8f0;
+  }
+
+  .app__table table {
+    background: rgba(15, 23, 42, 0.9);
+  }
+
+  .app__table thead {
+    background: rgba(15, 23, 42, 0.85);
+  }
+
+  .status-message {
+    background: rgba(59, 130, 246, 0.25);
+    color: #93c5fd;
+  }
+
+  .status-message[data-variant='error'] {
+    background: rgba(239, 68, 68, 0.25);
+    color: #fecaca;
+  }
+
+  .status-message[data-variant='success'] {
+    background: rgba(34, 197, 94, 0.25);
+    color: #bbf7d0;
+  }
+}


### PR DESCRIPTION
## Summary
- add an export button and import file input to the logs interface
- implement handlers to serialize logs to JSON, download them, and load validated logs from disk
- refresh persistence and table rendering whenever logs change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df2c06761c832fa5883cc21d77dadf