### PR TITLE
Add underwriting evaluation demo with UI and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "uwengine",
+  "version": "1.0.0",
+  "description": "Underwriting evaluation engine demo",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node tests/run-tests.js"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+import http from 'http';
+import { createReadStream, existsSync } from 'fs';
+import { join, extname } from 'path';
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = new URL('./src', import.meta.url).pathname;
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json'
+};
+
+const server = http.createServer((req, res) => {
+  const path = req.url === '/' ? '/index.html' : req.url;
+  const filePath = join(PUBLIC_DIR, path);
+  if (!existsSync(filePath)) {
+    res.writeHead(404);
+    res.end('Not found');
+    return;
+  }
+
+  const ext = extname(filePath);
+  res.writeHead(200, { 'Content-Type': MIME_TYPES[ext] || 'application/octet-stream' });
+  createReadStream(filePath).pipe(res);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,225 @@
+import { evaluateClientForCarrier, normalizeOutcome } from './evaluator.js';
+import { sampleCarriers } from './data.js';
+import { OUTCOME_ORDER } from './constants.js';
+
+const carrierSelect = document.querySelector('#carrierSelect');
+const conditionsInput = document.querySelector('#conditionsInput');
+const evalButton = document.querySelector('#evalButton');
+const resultsContainer = document.querySelector('#results');
+const banner = document.querySelector('#importBanner');
+const ruleList = document.querySelector('#ruleList');
+const importButton = document.querySelector('#importButton');
+
+let carriers = [];
+let selectedCarrierIds = new Set();
+
+function updateBanner() {
+  const shouldShow = carriers.length === 0;
+  banner.classList.toggle('hidden', !shouldShow);
+  banner.setAttribute('aria-hidden', String(!shouldShow));
+}
+
+function updateEvalState() {
+  const hasCarrierSelected = selectedCarrierIds.size > 0;
+  const hasConditions = conditionsInput.value.trim().length > 0;
+  evalButton.disabled = !(hasCarrierSelected && hasConditions);
+}
+
+function renderCarrierOptions() {
+  carrierSelect.innerHTML = '';
+  carriers.forEach(carrier => {
+    const option = document.createElement('option');
+    option.value = carrier.id;
+    option.textContent = carrier.name;
+    option.selected = selectedCarrierIds.has(carrier.id);
+    carrierSelect.appendChild(option);
+  });
+}
+
+function findDuplicateCriteria(rules) {
+  const seen = new Map();
+  const duplicates = new Set();
+
+  rules.forEach(rule => {
+    const key = (rule.criteria ?? '').trim();
+    if (!key) {
+      return;
+    }
+    if (seen.has(key)) {
+      duplicates.add(key);
+    }
+    seen.set(key, rule.id);
+  });
+
+  return duplicates;
+}
+
+function renderRules() {
+  ruleList.innerHTML = '';
+  if (selectedCarrierIds.size === 0) {
+    return;
+  }
+
+  selectedCarrierIds.forEach(carrierId => {
+    const carrier = carriers.find(item => item.id === carrierId);
+    if (!carrier) {
+      return;
+    }
+
+    const header = document.createElement('h3');
+    header.textContent = `${carrier.name} Rules`;
+    ruleList.appendChild(header);
+
+    const duplicates = findDuplicateCriteria(carrier.rules || []);
+    if (duplicates.size > 0) {
+      console.warn('Duplicate underwriting criteria detected', {
+        carrier: carrier.name,
+        criteria: Array.from(duplicates)
+      });
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'rule-list';
+
+    carrier.rules?.forEach(rule => {
+      const item = document.createElement('li');
+      item.className = 'rule-item';
+      const duplicate = duplicates.has((rule.criteria ?? '').trim());
+      if (duplicate) {
+        item.classList.add('duplicate');
+      }
+
+      const name = document.createElement('div');
+      name.className = 'rule-name';
+      name.textContent = rule.name ?? rule.id;
+
+      const criteria = document.createElement('code');
+      criteria.textContent = rule.criteria ?? 'No criteria';
+
+      const outcome = document.createElement('span');
+      outcome.className = 'rule-outcome';
+      outcome.textContent = `Outcome: ${normalizeOutcome(rule.outcome)}`;
+
+      item.appendChild(name);
+      if (duplicate) {
+        const badge = document.createElement('span');
+        badge.className = 'duplicate-badge';
+        badge.textContent = 'Duplicate criteria';
+        item.appendChild(badge);
+      }
+      item.appendChild(criteria);
+      item.appendChild(outcome);
+      list.appendChild(item);
+    });
+
+    ruleList.appendChild(list);
+  });
+}
+
+function renderResults(evaluations) {
+  resultsContainer.innerHTML = '';
+  evaluations.forEach(evaluation => {
+    const card = document.createElement('article');
+    card.className = 'result-card';
+
+    const header = document.createElement('header');
+    header.textContent = evaluation.carrier.name;
+
+    const outcome = document.createElement('p');
+    outcome.innerHTML = `<strong>Outcome:</strong> ${evaluation.outcome}`;
+
+    const weight = document.createElement('p');
+    weight.innerHTML = `<strong>Weight:</strong> ${evaluation.weight.toFixed(2)}`;
+
+    const probabilityHeader = document.createElement('h4');
+    probabilityHeader.textContent = 'Probability Distribution';
+
+    const probabilityList = document.createElement('ul');
+    probabilityList.className = 'probability-list';
+
+    OUTCOME_ORDER.forEach(outcomeLabel => {
+      const item = document.createElement('li');
+      const value = evaluation.probabilities[outcomeLabel] ?? 0;
+      item.textContent = `${outcomeLabel}: ${(value * 100).toFixed(1)}%`;
+      probabilityList.appendChild(item);
+    });
+
+    card.appendChild(header);
+    card.appendChild(outcome);
+    card.appendChild(weight);
+    card.appendChild(probabilityHeader);
+    card.appendChild(probabilityList);
+    resultsContainer.appendChild(card);
+  });
+}
+
+function parseClientConditions() {
+  try {
+    const parsed = JSON.parse(conditionsInput.value || '{}');
+    return parsed;
+  } catch (error) {
+    alert('Invalid JSON for client conditions. Please correct and try again.');
+    throw error;
+  }
+}
+
+function handleEvaluate() {
+  try {
+    const client = parseClientConditions();
+    const evaluations = Array.from(selectedCarrierIds)
+      .map(carrierId => carriers.find(carrier => carrier.id === carrierId))
+      .filter(Boolean)
+      .map(carrier => {
+        const evaluation = evaluateClientForCarrier(client, carrier);
+        return {
+          carrier,
+          ...evaluation
+        };
+      });
+
+    renderResults(evaluations);
+  } catch (error) {
+    console.error('Unable to evaluate client', error);
+  }
+}
+
+carrierSelect.addEventListener('change', event => {
+  selectedCarrierIds = new Set(Array.from(event.target.selectedOptions).map(option => option.value));
+  updateEvalState();
+  renderRules();
+});
+
+evalButton.addEventListener('click', event => {
+  event.preventDefault();
+  handleEvaluate();
+});
+
+conditionsInput.addEventListener('input', () => {
+  updateEvalState();
+});
+
+importButton.addEventListener('click', () => {
+  carriers = sampleCarriers.slice();
+  selectedCarrierIds = new Set(carriers.map(carrier => carrier.id));
+  updateBanner();
+  renderCarrierOptions();
+  renderRules();
+  updateEvalState();
+});
+
+function bootstrap() {
+  conditionsInput.value = JSON.stringify(
+    {
+      age: 35,
+      creditScore: 710,
+      smoker: false,
+      bmi: 24
+    },
+    null,
+    2
+  );
+  updateBanner();
+  updateEvalState();
+}
+
+bootstrap();

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,10 @@
+export const OUTCOME_ORDER = [
+  'Preferred',
+  'Standard',
+  'Substandard',
+  'Decline',
+  'N/A'
+];
+
+export const DEFAULT_OUTCOME = 'Standard';
+export const NEUTRAL_WEIGHT = 1;

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,77 @@
+export const sampleCarriers = [
+  {
+    id: 'carrier-a',
+    name: 'Carrier A',
+    baseOutcome: 'Standard',
+    baseWeight: 1,
+    baseProbabilities: {
+      Preferred: 0.4,
+      Standard: 0.4,
+      Substandard: 0.2
+    },
+    rules: [
+      {
+        id: 'a-1',
+        name: 'Young Preferred',
+        criteria: 'client.age < 30 && client.creditScore >= 720',
+        outcome: 'Preferred',
+        weight: 1.3,
+        priority: 2,
+        probabilityShift: {
+          Preferred: 0.2,
+          Standard: -0.2
+        }
+      },
+      {
+        id: 'a-2',
+        name: 'High Risk',
+        criteria: 'client.smoker === true || client.bmi > 32',
+        outcome: 'Decline',
+        weight: 0.7,
+        priority: 3,
+        probabilityShift: {
+          Decline: 0.4,
+          Standard: -0.3,
+          Substandard: -0.1
+        }
+      },
+      {
+        id: 'a-3',
+        name: 'Duplicate Warning',
+        criteria: 'client.smoker === true || client.bmi > 32',
+        outcome: 'Decline',
+        weight: 0.6,
+        priority: 1,
+        probabilityShift: {
+          Decline: 0.1,
+          Standard: -0.1
+        }
+      }
+    ]
+  },
+  {
+    id: 'carrier-b',
+    name: 'Carrier B',
+    baseOutcome: 'Standard',
+    baseWeight: 1,
+    baseProbabilities: {
+      Preferred: 0.3,
+      Standard: 0.5,
+      Substandard: 0.2
+    },
+    rules: [
+      {
+        id: 'b-1',
+        name: 'Wellness',
+        criteria: '!client.smoker && client.bmi < 27',
+        outcome: 'Elite Preferred',
+        weight: 1.2,
+        priority: 1,
+        probabilityShift: {
+          Preferred: 0.1,
+          Standard: -0.1
+        }
+      }
+    ]
+  }
+];

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -1,0 +1,151 @@
+import { DEFAULT_OUTCOME, NEUTRAL_WEIGHT, OUTCOME_ORDER } from './constants.js';
+
+function normalizeOutcome(rawOutcome, outcomeOrder = OUTCOME_ORDER) {
+  if (!rawOutcome || typeof rawOutcome !== 'string') {
+    return DEFAULT_OUTCOME;
+  }
+
+  const trimmed = rawOutcome.trim();
+  const lower = trimmed.toLowerCase();
+
+  const exact = outcomeOrder.find(label => label.toLowerCase() === lower);
+  if (exact) {
+    return exact;
+  }
+
+  const partial = outcomeOrder.find(label => {
+    const normalizedLabel = label.toLowerCase();
+    return (
+      normalizedLabel.startsWith(lower) ||
+      lower.startsWith(normalizedLabel) ||
+      normalizedLabel.includes(lower) ||
+      lower.includes(normalizedLabel)
+    );
+  });
+  if (partial) {
+    return partial;
+  }
+
+  return DEFAULT_OUTCOME;
+}
+
+function safeEvaluate(criteria, context) {
+  if (!criteria || typeof criteria !== 'string') {
+    return false;
+  }
+
+  try {
+    // eslint-disable-next-line no-new-func
+    const evaluator = new Function(...Object.keys(context), `return (${criteria});`);
+    const result = evaluator(...Object.values(context));
+    return Boolean(result);
+  } catch (error) {
+    console.warn('Failed to evaluate rule criteria', criteria, error);
+    return false;
+  }
+}
+
+function cloneProbabilities(base, order = OUTCOME_ORDER) {
+  const result = {};
+  order.forEach(outcome => {
+    const normalized = normalizeOutcome(outcome, order);
+    result[normalized] = Number(base?.[normalized] ?? 0);
+  });
+  return result;
+}
+
+function applyProbabilityShift(probabilities, shift, order = OUTCOME_ORDER, observed = new Set()) {
+  if (!shift) {
+    return observed;
+  }
+
+  Object.entries(shift).forEach(([rawOutcome, delta]) => {
+    const outcome = normalizeOutcome(rawOutcome, order);
+    if (!Number.isFinite(delta)) {
+      return;
+    }
+    observed.add(outcome);
+    probabilities[outcome] = Number(probabilities[outcome] ?? 0) + delta;
+  });
+
+  return observed;
+}
+
+function normalizeProbabilityDistribution(probabilities, observed, order = OUTCOME_ORDER) {
+  const outcomes = order.map(outcome => normalizeOutcome(outcome, order));
+  outcomes.forEach(outcome => {
+    if (!Object.prototype.hasOwnProperty.call(probabilities, outcome)) {
+      probabilities[outcome] = 0;
+    }
+  });
+
+  const sum = Object.values(probabilities).reduce((acc, value) => acc + value, 0);
+  const observedList = Array.from(observed).filter(outcome => outcomes.includes(outcome));
+
+  if (Math.abs(sum) < Number.EPSILON && observedList.length > 0) {
+    const share = 1 / observedList.length;
+    observedList.forEach(outcome => {
+      probabilities[outcome] = share;
+    });
+    outcomes
+      .filter(outcome => !observedList.includes(outcome))
+      .forEach(outcome => {
+        probabilities[outcome] = 0;
+      });
+    return probabilities;
+  }
+
+  if (sum > 0) {
+    Object.keys(probabilities).forEach(outcome => {
+      probabilities[outcome] = probabilities[outcome] / sum;
+    });
+  }
+
+  return probabilities;
+}
+
+export function evaluateClientForCarrier(client, carrier, options = {}) {
+  const outcomeOrder = options.outcomeOrder ?? OUTCOME_ORDER;
+  const context = { client, carrier };
+  const baseProbabilities = cloneProbabilities(carrier?.baseProbabilities ?? {}, outcomeOrder);
+  const observedOutcomes = new Set();
+  const rules = Array.isArray(carrier?.rules) ? carrier.rules : [];
+
+  const matchedRules = rules.filter(rule => safeEvaluate(rule.criteria, context));
+
+  let outcome = normalizeOutcome(carrier?.baseOutcome, outcomeOrder);
+  let weight = Number(carrier?.baseWeight ?? NEUTRAL_WEIGHT);
+
+  if (matchedRules.length === 0) {
+    outcome = normalizeOutcome('N/A', outcomeOrder);
+    weight = NEUTRAL_WEIGHT;
+  } else {
+    matchedRules.forEach(rule => {
+      if (rule.probabilityShift) {
+        applyProbabilityShift(baseProbabilities, rule.probabilityShift, outcomeOrder, observedOutcomes);
+      }
+    });
+
+    const prioritizedRule = matchedRules
+      .slice()
+      .sort((a, b) => (Number(b.priority ?? 0) - Number(a.priority ?? 0)))[0];
+
+    if (prioritizedRule) {
+      outcome = normalizeOutcome(prioritizedRule.outcome, outcomeOrder);
+      if (Number.isFinite(Number(prioritizedRule.weight))) {
+        weight = Number(prioritizedRule.weight);
+      }
+    }
+  }
+
+  normalizeProbabilityDistribution(baseProbabilities, observedOutcomes, outcomeOrder);
+
+  return {
+    outcome,
+    weight,
+    matches: matchedRules,
+    probabilities: baseProbabilities
+  };
+}
+
+export { normalizeOutcome, safeEvaluate, normalizeProbabilityDistribution };

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Underwriting Evaluation Engine</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Underwriting Evaluation Engine</h1>
+    </header>
+    <main>
+      <section class="controls">
+        <div id="importBanner" class="banner" role="alert">Import carriers to run an evaluation.</div>
+        <div class="control-group">
+          <button id="importButton" class="primary">Import sample carriers</button>
+        </div>
+        <div class="control-group">
+          <label for="carrierSelect">Select carriers</label>
+          <select id="carrierSelect" multiple aria-describedby="carrierHelp"></select>
+          <small id="carrierHelp">Hold Ctrl (Windows) or Command (Mac) to select multiple carriers.</small>
+        </div>
+        <div class="control-group">
+          <label for="conditionsInput">Client conditions (JSON)</label>
+          <textarea id="conditionsInput" rows="6" spellcheck="false"></textarea>
+        </div>
+        <div class="control-group">
+          <button id="evalButton" class="primary" disabled>Evaluate</button>
+        </div>
+      </section>
+      <section>
+        <h2>Rules</h2>
+        <div id="ruleList" class="rule-container"></div>
+      </section>
+      <section>
+        <h2>Results</h2>
+        <div id="results" class="results"></div>
+      </section>
+    </main>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  background-color: #f5f5f5;
+  color: #1d1d1f;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+main {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.page-header {
+  background: #001f3f;
+  color: #fff;
+  padding: 1rem 1.5rem;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+textarea {
+  min-height: 160px;
+  font-family: 'Fira Code', 'Courier New', Courier, monospace;
+}
+
+button.primary {
+  background-color: #2f5af3;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+button.primary:disabled {
+  cursor: not-allowed;
+  background-color: #9aa5b1;
+}
+
+.banner {
+  background-color: #fff3cd;
+  color: #856404;
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #ffeeba;
+}
+
+.banner.hidden {
+  display: none;
+}
+
+.rule-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rule-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.rule-item {
+  background: #fff;
+  border-radius: 6px;
+  padding: 0.75rem;
+  border: 1px solid #d7d9dd;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.rule-item.duplicate {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.15);
+}
+
+.duplicate-badge {
+  align-self: flex-start;
+  background: #dc3545;
+  color: #fff;
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.results {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.result-card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.probability-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+@media (max-width: 900px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/evaluator.test.js
+++ b/tests/evaluator.test.js
@@ -1,0 +1,136 @@
+import assert from 'assert/strict';
+import { evaluateClientForCarrier, normalizeProbabilityDistribution, safeEvaluate } from '../src/evaluator.js';
+import { OUTCOME_ORDER } from '../src/constants.js';
+
+const client = {
+  age: 45,
+  creditScore: 680,
+  smoker: false,
+  bmi: 29
+};
+
+const carrier = {
+  id: 'test',
+  name: 'Test Carrier',
+  baseOutcome: 'Standard',
+  baseWeight: 1,
+  baseProbabilities: {
+    Preferred: 0.3,
+    Standard: 0.4,
+    Substandard: 0.3
+  },
+  rules: [
+    {
+      id: 'one',
+      criteria: 'client.age < 30',
+      outcome: 'Preferred',
+      weight: 1.4,
+      priority: 1,
+      probabilityShift: {
+        Preferred: 0.1,
+        Standard: -0.1
+      }
+    }
+  ]
+};
+
+const errorRule = {
+  id: 'error',
+  criteria: 'client.missing.value > 1',
+  outcome: 'Decline',
+  weight: 0.9
+};
+
+function createCarrier(overrides = {}) {
+  return {
+    ...carrier,
+    rules: [...carrier.rules],
+    ...overrides
+  };
+}
+
+describe('evaluateClientForCarrier', () => {
+  it('returns N/A outcome and neutral weight when no rules match', () => {
+    const evaluation = evaluateClientForCarrier(client, createCarrier({ rules: [] }));
+    assert.equal(evaluation.outcome, 'N/A');
+    assert.equal(evaluation.weight, 1);
+  });
+
+  it('maps unknown outcomes to Standard by default', () => {
+    const evaluation = evaluateClientForCarrier(client, createCarrier({
+      rules: [
+        {
+          ...carrier.rules[0],
+          criteria: 'client.age > 40',
+          outcome: 'Elite Preferred'
+        }
+      ]
+    }));
+    assert.equal(evaluation.outcome, 'Preferred');
+  });
+
+  it('redistributes zero-sum probability shifts evenly across observed outcomes', () => {
+    const evaluation = evaluateClientForCarrier(client, createCarrier({
+      baseProbabilities: {},
+      rules: [
+        {
+          ...carrier.rules[0],
+          criteria: 'client.age > 40',
+          probabilityShift: {
+            Preferred: 0.4,
+            Standard: -0.4
+          }
+        }
+      ]
+    }));
+    const values = evaluation.probabilities;
+    assert.equal(values.Preferred, 0.5);
+    assert.equal(values.Standard, 0.5);
+  });
+
+  it('guards expression evaluation errors and treats them as non-matches', () => {
+    const evaluation = evaluateClientForCarrier(client, createCarrier({ rules: [errorRule] }));
+    assert.equal(evaluation.matches.length, 0);
+  });
+});
+
+describe('normalizeProbabilityDistribution', () => {
+  it('spreads zero-sum across observed outcomes evenly', () => {
+    const probabilities = {
+      Preferred: 0.1,
+      Standard: -0.1,
+      Substandard: 0
+    };
+    const observed = new Set(['Preferred', 'Standard']);
+    const normalized = normalizeProbabilityDistribution(probabilities, observed, OUTCOME_ORDER);
+    assert.equal(normalized.Preferred, 0.5);
+    assert.equal(normalized.Standard, 0.5);
+  });
+});
+
+describe('safeEvaluate', () => {
+  it('returns false when runtime errors occur', () => {
+    const result = safeEvaluate('client.missing.value > 1', { client: {} });
+    assert.equal(result, false);
+  });
+});
+
+function describe(name, fn) {
+  console.group(name);
+  try {
+    fn();
+  } finally {
+    console.groupEnd(name);
+  }
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}`);
+    console.error(error);
+    throw error;
+  }
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const testDir = __dirname;
+const files = fs
+  .readdirSync(testDir)
+  .filter(file => file.endsWith('.test.js'))
+  .map(file => join(testDir, file));
+
+let failed = 0;
+
+for (const file of files) {
+  try {
+    // eslint-disable-next-line no-await-in-loop
+    await import(fileToUrl(file));
+    console.log(`✓ ${file}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`✗ ${file}`);
+    console.error(error);
+  }
+}
+
+if (failed > 0) {
+  process.exitCode = 1;
+}
+
+function fileToUrl(file) {
+  return new URL(file, 'file://');
+}


### PR DESCRIPTION
## Summary
- implement an underwriting evaluator that normalizes outcomes, guards rule execution failures, and balances zero-sum probability shifts
- add a browser UI that disables evaluation until carriers are loaded, surfaces an import banner, and highlights duplicate rule criteria
- include sample carrier data, a static server, and regression tests covering evaluator edge cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df2c07417c832fa94c83595dfb2081